### PR TITLE
fix!: rename shufflings to shuffles

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,13 +19,13 @@ pub struct Cli {
 
     /// Path to a shuffled database file
     ///
-    /// Uses a file containing the shuffled database instead of generating one on the fly. 
+    /// Uses a file containing the shuffled database instead of generating one on the fly.
     /// A shuffled database can be dumped to file using `--dump-shuffled-db`.
     #[clap(
         long,
         conflicts_with_all = &[
             "dump_shuffled_db",
-            "db_shufflings",
+            "db_shuffles",
             "db_block_size",
             "db_in_block_shuffle",
         ],
@@ -69,9 +69,9 @@ pub struct Cli {
     #[clap(long)]
     pub threads: Option<u16>,
 
-    /// Number of shufflings to perform for each sequence in db
-    #[clap(long, alias = "dbShufflings", default_value_t = 100)]
-    pub db_shufflings: u16,
+    /// Number of shuffles to perform for each sequence in db
+    #[clap(long, alias = "dbShuffles", default_value_t = 100)]
+    pub db_shuffles: u16,
 
     /// Size (in nt) of the blocks for shuffling the sequences in db
     #[clap(long, alias = "dbBlockSize", default_value_t = 10)]
@@ -121,10 +121,7 @@ pub struct Cli {
     #[serde(flatten)]
     pub alignment_args: AlignmentArgs,
 
-    #[clap(
-        flatten,
-        next_help_heading = r#"Alignment folding evaluation options"#
-    )]
+    #[clap(flatten, next_help_heading = r#"Alignment folding evaluation options"#)]
     #[serde(flatten)]
     pub alignment_folding_eval_args: AlignmentFoldingEvaluationArgs,
 }
@@ -248,9 +245,9 @@ pub struct AlignmentFoldingEvaluationArgs {
     #[clap(long, alias = "evalAlignFold")]
     pub eval_align_fold: bool,
 
-    /// Number of shufflings to perform for each alignment during folding evaluation
+    /// Number of shuffles to perform for each alignment during folding evaluation
     #[clap(long, default_value_t = 100)]
-    pub shufflings: u16,
+    pub shuffles: u16,
 
     /// Size (in nt) of the blocks for shuffling the alignment during folding evaluation
     #[clap(long, alias = "blockSize", default_value_t = 3)]
@@ -417,9 +414,9 @@ pub struct Alternative {
     #[clap(long)]
     pub threads: Option<u16>,
 
-    /// Number of shufflings to perform for each sequence in db
-    #[clap(long, alias = "dbShufflings", default_value_t = 100)]
-    pub db_shufflings: u16,
+    /// Number of shuffles to perform for each sequence in db
+    #[clap(long, alias = "dbShuffles", default_value_t = 100)]
+    pub db_shuffles: u16,
 
     /// Size (in nt) of the blocks for shuffling the sequences in db
     #[clap(long, alias = "dbBlockSize", default_value_t = 10)]

--- a/src/handle_query_entry.rs
+++ b/src/handle_query_entry.rs
@@ -291,8 +291,8 @@ impl<'a> QueryResultHandler<'a> {
 
         let block_size = cli.alignment_folding_eval_args.block_size;
         null_model_energies.clear();
-        null_model_energies.extend((0..cli.alignment_folding_eval_args.shufflings).map(
-            move |_| match &mut block_indices_buffer {
+        null_model_energies.extend((0..cli.alignment_folding_eval_args.shuffles).map(move |_| {
+            match &mut block_indices_buffer {
                 Some(block_indices_buffer) => {
                     let gapped_data = gapped_data.clone().shuffled_in_blocks(
                         block_size,
@@ -318,8 +318,8 @@ impl<'a> QueryResultHandler<'a> {
 
                     mfe
                 }
-            },
-        ));
+            }
+        }));
         let dist = NormDist::from_sample(null_model_energies.as_slice());
         let z_score = dist.z_score(mfe);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> anyhow::Result<()> {
         overwrite,
         ref output,
         threads,
-        db_shufflings,
+        db_shuffles,
         db_block_size,
         ..
     } = cli;
@@ -150,7 +150,7 @@ fn main() -> anyhow::Result<()> {
             make_shuffled_db(
                 &db_entries,
                 db_block_size.into(),
-                db_shufflings.into(),
+                db_shuffles.into(),
                 cli.db_in_block_shuffle,
             )
         });
@@ -197,7 +197,7 @@ fn parse_cli_or_try_alternative() -> anyhow::Result<Cli> {
             dump_db,
             dump_shuffled_db,
             threads,
-            db_shufflings,
+            db_shuffles,
             db_block_size,
             db_in_block_shuffle,
         }) = cli::Alternative::try_parse()
@@ -219,7 +219,7 @@ fn parse_cli_or_try_alternative() -> anyhow::Result<Cli> {
                 let db_shuffled = make_shuffled_db(
                     &db,
                     db_block_size.into(),
-                    db_shufflings.into(),
+                    db_shuffles.into(),
                     db_in_block_shuffle,
                 );
 


### PR DESCRIPTION
Because "shufflings" is not an actual word 😅.